### PR TITLE
Added safer removal of views

### DIFF
--- a/Classes/AHKActionSheet.m
+++ b/Classes/AHKActionSheet.m
@@ -323,9 +323,14 @@ static const CGFloat kCancelButtonShadowHeightRatio = 0.333f;
 
     void(^tearDownView)(void) = ^(void) {
         // remove the views because it's easiest to just recreate them if the action sheet is shown again
-        for (UIView *view in @[self.tableView, self.cancelButton, self.blurredBackgroundView, self.window]) {
-            [view removeFromSuperview];
-        }
+        if(self.tableView)
+            [self.tableView removeFromSuperview];
+        if( self.cancelButton)
+            [self.cancelButton removeFromSuperview];
+        if(self.blurredBackgroundView)
+            [self.blurredBackgroundView removeFromSuperview];
+        if(self.window)
+            [self.window removeFromSuperview];
 
         self.window = nil;
         [self.previousKeyWindow makeKeyAndVisible];


### PR DESCRIPTION
Was crashing when dismissing the view stating attempting to add a 'nil' object to array. This fixed that problem for me.
