### PR TITLE
Add accessory parameter to enable to put a accessory on buttons.

### DIFF
--- a/Classes/AHKActionSheet.h
+++ b/Classes/AHKActionSheet.h
@@ -97,6 +97,15 @@ typedef void(^AHKActionSheetHandler)(AHKActionSheet *actionSheet);
  */
 - (void)addButtonWithTitle:(NSString *)title image:(UIImage *)image type:(AHKActionSheetButtonType)type handler:(AHKActionSheetHandler)handler;
 
+/**
+ *  Adds a button without an image. Has to be called before showing the action sheet.
+ *
+ *  @param image     The image to display on the left of the title.
+ *  @param accessory The accessory to display on the right of the title.
+ *  @param handler   A completion handler block to execute when a dismissal animation (after the user tapped on the button) has finished.
+ */
+- (void)addButtonWithTitle:(NSString *)title image:(UIImage *)image accessory:(UITableViewCellAccessoryType)accessory type:(AHKActionSheetButtonType)type handler:(AHKActionSheetHandler)handler;
+
 /// Displays the action sheet.
 - (void)show;
 

--- a/Classes/AHKActionSheet.m
+++ b/Classes/AHKActionSheet.m
@@ -32,6 +32,7 @@ static const CGFloat kCancelButtonShadowHeightRatio = 0.333f;
 @interface AHKActionSheetItem : NSObject
 @property (copy, nonatomic) NSString *title;
 @property (strong, nonatomic) UIImage *image;
+@property (nonatomic) UITableViewCellAccessoryType accessory;
 @property (nonatomic) AHKActionSheetButtonType type;
 @property (strong, nonatomic) AHKActionSheetHandler handler;
 @end
@@ -152,6 +153,8 @@ static const CGFloat kCancelButtonShadowHeightRatio = 0.333f;
         cell.imageView.tintColor = attributes[NSForegroundColorAttributeName] ? attributes[NSForegroundColorAttributeName] : [UIColor blackColor];
     }
 
+    cell.accessoryType = item.accessory;
+
     cell.backgroundColor = [UIColor clearColor];
 
     if (self.selectedBackgroundColor && ![cell.selectedBackgroundView.backgroundColor isEqual:self.selectedBackgroundColor]) {
@@ -235,9 +238,15 @@ static const CGFloat kCancelButtonShadowHeightRatio = 0.333f;
 
 - (void)addButtonWithTitle:(NSString *)title image:(UIImage *)image type:(AHKActionSheetButtonType)type handler:(AHKActionSheetHandler)handler
 {
+    [self addButtonWithTitle:title image:nil accessory:UITableViewCellAccessoryNone type:type handler:handler];
+}
+
+- (void)addButtonWithTitle:(NSString *)title image:(UIImage *)image accessory:(UITableViewCellAccessoryType)accessory type:(AHKActionSheetButtonType)type handler:(AHKActionSheetHandler)handler
+{
     AHKActionSheetItem *item = [[AHKActionSheetItem alloc] init];
     item.title = title;
     item.image = image;
+    item.accessory = accessory;
     item.type = type;
     item.handler = handler;
     [self.items addObject:item];


### PR DESCRIPTION
Added UITableViewCellAccessory parameter to enable to put a accessory on buttons of the AHKActionSheet.

This commit enable to set UITableViewCellAccessory on the buttons.
Default accessory parameter is UITableViewCellAccessoryNone if people do not set the parameter.