### PR TITLE
Removed tableView separator Insets for iOS 8, Removed tableView separators under the footer & Added functionality for centering the title text

### DIFF
--- a/Classes/AHKActionSheet.h
+++ b/Classes/AHKActionSheet.h
@@ -44,6 +44,8 @@ typedef void(^AHKActionSheetHandler)(AHKActionSheet *actionSheet);
 @property (strong, nonatomic) NSNumber *automaticallyTintButtonImages UI_APPEARANCE_SELECTOR;
 /// Boxed boolean value. Useful when adding buttons without images (in that case text looks better centered). Disabled by default.
 @property (strong, nonatomic) NSNumber *buttonTextCenteringEnabled UI_APPEARANCE_SELECTOR;
+/// Boxed boolean value. Disabled by default.
+@property (strong, nonatomic) NSNumber *titleTextCenteringEnabled UI_APPEARANCE_SELECTOR;
 /// Color of the separator between buttons.
 @property (strong, nonatomic) UIColor *separatorColor UI_APPEARANCE_SELECTOR;
 /// Background color of the button when it's tapped (internally it's a UITableViewCell)

--- a/Classes/AHKActionSheet.m
+++ b/Classes/AHKActionSheet.m
@@ -483,6 +483,11 @@ static const CGFloat kCancelButtonShadowHeightRatio = 0.333f;
         CGSize labelSize = [label sizeThatFits:CGSizeMake(labelWidth, MAXFLOAT)];
         label.frame = CGRectMake(leftRightPadding, topBottomPadding, labelWidth, labelSize.height);
         label.backgroundColor = [UIColor clearColor];
+        
+        if (self.titleTextCenteringEnabled && [self.titleTextCenteringEnabled boolValue])
+        {
+            label.textAlignment = NSTextAlignmentCenter;
+        }
 
         // create and add a header consisting of the label
         UIView *headerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.bounds), labelSize.height + 2*topBottomPadding)];

--- a/Classes/AHKActionSheet.m
+++ b/Classes/AHKActionSheet.m
@@ -178,6 +178,24 @@ static const CGFloat kCancelButtonShadowHeightRatio = 0.333f;
     return self.buttonHeight;
 }
 
+-(void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    // Remove separator inset as described here: http://stackoverflow.com/a/25877725/783960
+    if ([cell respondsToSelector:@selector(setSeparatorInset:)]) {
+        [cell setSeparatorInset:UIEdgeInsetsZero];
+    }
+    
+    // Prevent the cell from inheriting the Table View's margin settings
+    if ([cell respondsToSelector:@selector(setPreservesSuperviewLayoutMargins:)]) {
+        [cell setPreservesSuperviewLayoutMargins:NO];
+    }
+    
+    // Explictly set your cell's layout margins
+    if ([cell respondsToSelector:@selector(setLayoutMargins:)]) {
+        [cell setLayoutMargins:UIEdgeInsetsZero];
+    }
+}
+
 #pragma mark - UIScrollViewDelegate
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
@@ -445,10 +463,6 @@ static const CGFloat kCancelButtonShadowHeightRatio = 0.333f;
     UITableView *tableView = [[UITableView alloc] initWithFrame:frame];
     tableView.backgroundColor = [UIColor clearColor];
     tableView.showsVerticalScrollIndicator = NO;
-
-    if ([UITableView instancesRespondToSelector:@selector(setSeparatorInset:)]) {
-        tableView.separatorInset = UIEdgeInsetsZero;
-    }
 
     if (self.separatorColor) {
         tableView.separatorColor = self.separatorColor;

--- a/Classes/AHKActionSheet.m
+++ b/Classes/AHKActionSheet.m
@@ -474,6 +474,7 @@ static const CGFloat kCancelButtonShadowHeightRatio = 0.333f;
     [self insertSubview:tableView aboveSubview:self.blurredBackgroundView];
     // move the content below the screen, ready to be animated in -show
     tableView.contentInset = UIEdgeInsetsMake(CGRectGetHeight(self.bounds), 0, 0, 0);
+    tableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectZero];
 
     self.tableView = tableView;
 


### PR DESCRIPTION
Did some tableview related changes:
- UITableView separator insets was visible in iOS 8 so I removed them as described here: http://stackoverflow.com/questions/25770119/ios-8-uitableview-separator-inset-0-not-working/25877725#25877725
- When a user scrolls past the bottom of the tableview, separators for non-existent cells were present. Added an empty footer to the UITableView to hide them.
- I found it useful to enable centering the title text. Added a property that is compliant with UIAppearance for that functionality.