### PR TITLE
cancelOnTapEmptyAreaEnabled - if YES, dismisses control if user taps on an empty area

### DIFF
--- a/Classes/AHKActionSheet.h
+++ b/Classes/AHKActionSheet.h
@@ -59,6 +59,10 @@ typedef void(^AHKActionSheetHandler)(AHKActionSheet *actionSheet);
 
 /// Boxed boolean value. Enables/disables control hiding with pan gesture. Enabled by default.
 @property (strong, nonatomic) NSNumber *cancelOnPanGestureEnabled UI_APPEARANCE_SELECTOR;
+
+/// Boxed boolean value. Enables/disables control hiding when tapped on empty area. Disabled by default.
+@property (strong, nonatomic) NSNumber *cancelOnTapEmptyAreaEnabled UI_APPEARANCE_SELECTOR;
+
 /// A handler called on every type of dismissal (tapping on "Cancel" or swipe down or flick down).
 @property (strong, nonatomic) AHKActionSheetHandler cancelHandler;
 @property (copy, nonatomic) NSString *cancelButtonTitle;


### PR DESCRIPTION
if cancelOnTapEmptyAreaEnabled is YES, then control will hide when the
user taps on an empty area. (everywhere that is not a button (technically UITableViewCell)).

as seen in the Spotify app!:)