### PR TITLE
Get rid of the warning in Xcode 7

### DIFF
--- a/AHKActionSheetExample/AHKActionSheetExample.xcodeproj/project.pbxproj
+++ b/AHKActionSheetExample/AHKActionSheetExample.xcodeproj/project.pbxproj
@@ -226,7 +226,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = AHK;
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Arkadiusz Holko";
 				TargetAttributes = {
 					A6BA55D018F3F7840009AC11 = {
@@ -353,6 +353,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -432,6 +433,7 @@
 					"-Wno-unused-parameter",
 					"-Wunreachable-code",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "pl.holko.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -464,6 +466,7 @@
 					"-Wno-unused-parameter",
 					"-Wunreachable-code",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "pl.holko.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -485,6 +488,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "AHKActionSheetExampleTests/AHKActionSheetExampleTests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "pl.holko.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;
@@ -503,6 +507,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "AHKActionSheetExample/AHKActionSheetExample-Prefix.pch";
 				INFOPLIST_FILE = "AHKActionSheetExampleTests/AHKActionSheetExampleTests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "pl.holko.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;

--- a/AHKActionSheetExample/AHKActionSheetExample/AHKActionSheetExample-Info.plist
+++ b/AHKActionSheetExample/AHKActionSheetExample/AHKActionSheetExample-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>pl.holko.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -24,6 +24,8 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>Main</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/AHKActionSheetExample/AHKActionSheetExampleTests/AHKActionSheetExampleTests-Info.plist
+++ b/AHKActionSheetExample/AHKActionSheetExampleTests/AHKActionSheetExampleTests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>pl.holko.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/Classes/AHKActionSheetViewController.m
+++ b/Classes/AHKActionSheetViewController.m
@@ -46,7 +46,7 @@
     return !self.viewAlreadyAppear;
 }
 
-- (NSUInteger)supportedInterfaceOrientations
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
     return UIInterfaceOrientationMaskAll;
 }


### PR DESCRIPTION
Hello! 

In Xcode 7, the ```NSUInteger``` return type for the ```supportedInterfaceOrientations``` was giving a warning, so we need to change it by  ```UIInterfaceOrientationMask``` in order to get rid of it.

This was the main reason of the PR, but I also updated the example project to the new project structure used by Xcode7. Besides that, in the demo project, the "Launch Screen File" was empty, which was causing this black bars appears when running the demo in Xcode 7.

![simulator screen shot 21 de out de 2015 08 29 17](https://cloud.githubusercontent.com/assets/1894401/10637889/67650960-77de-11e5-963e-0dd0832495a3.png)
