### PR TITLE
Fix row indentation on iPad

### DIFF
--- a/Classes/AHKActionSheet.m
+++ b/Classes/AHKActionSheet.m
@@ -476,6 +476,13 @@ static const CGFloat kCancelButtonShadowHeightRatio = 0.333f;
     if (self.separatorColor) {
         tableView.separatorColor = self.separatorColor;
     }
+    
+    // Fix indentation on iPad
+    // http://stackoverflow.com/questions/25770119/ios-8-uitableview-separator-inset-0-not-working/25877725#25877725
+    if([tableView respondsToSelector:@selector(setCellLayoutMarginsFollowReadableWidth:)])
+    {
+        tableView.cellLayoutMarginsFollowReadableWidth = NO;
+    }
 
     tableView.delegate = self;
     tableView.dataSource = self;


### PR DESCRIPTION
When using AHKActionSheet on an iPad, the rows get indented. This pull request fixes that indentation on the iPad.  See attached before and after screenshots.

![ahkactionsheet-before](https://cloud.githubusercontent.com/assets/3278390/13787047/85eeb5a8-ea97-11e5-86be-1a0e4b3769d2.png)
![ahkactionsheet-after](https://cloud.githubusercontent.com/assets/3278390/13787048/85ef6598-ea97-11e5-91b5-bc56aaad7ae9.png)
